### PR TITLE
Fix internship status display for teachers

### DIFF
--- a/simmas/resources/views/internships/edit.blade.php
+++ b/simmas/resources/views/internships/edit.blade.php
@@ -54,14 +54,14 @@
                             <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
                                 <div>
                                     <label class="block text-sm font-medium text-gray-700">Tanggal Mulai</label>
-                                    <input id="start_date" type="date" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 @error('start_date') border-red-300 @enderror" name="start_date" value="{{ old('start_date', $internship->start_date) }}" required>
+                                <input id="start_date" type="date" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 @error('start_date') border-red-300 @enderror" name="start_date" value="{{ old('start_date', optional($internship->start_date)->format('Y-m-d')) }}" required>
                                     @error('start_date')
                                         <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
                                     @enderror
                                 </div>
                                 <div>
                                     <label class="block text-sm font-medium text-gray-700">Tanggal Selesai</label>
-                                    <input id="end_date" type="date" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 @error('end_date') border-red-300 @enderror" name="end_date" value="{{ old('end_date', $internship->end_date) }}" required>
+                                    <input id="end_date" type="date" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 @error('end_date') border-red-300 @enderror" name="end_date" value="{{ old('end_date', optional($internship->end_date)->format('Y-m-d')) }}" required>
                                     @error('end_date')
                                         <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
                                     @enderror

--- a/simmas/resources/views/internships/index.blade.php
+++ b/simmas/resources/views/internships/index.blade.php
@@ -139,15 +139,13 @@
                                                 </div>
                                                 <div>
                                                     <div class="font-semibold text-gray-900">{{ $internship->student->name }}</div>
-                                                    <div class="text-sm text-gray-500">NIS: {{ $internship->student->nis ?? 'N/A' }}</div>
-                                                    <div class="text-xs text-gray-400">{{ $internship->student->class ?? 'N/A' }}</div>
-                                                    <div class="text-xs text-gray-400">{{ $internship->student->major ?? 'Rekayasa Perangkat Lunak' }}</div>
+                                                    <div class="text-sm text-gray-500">NIS/NIP: {{ $internship->student->nis_nip ?? 'N/A' }}</div>
                                                 </div>
                                             </div>
                                         </td>
                                         <td class="py-4 px-4">
                                             <div class="font-medium text-gray-900">{{ $internship->teacher->name }}</div>
-                                            <div class="text-sm text-gray-500">NIP: {{ $internship->teacher->nip ?? 'N/A' }}</div>
+                                            <div class="text-sm text-gray-500">NIP: {{ $internship->teacher->nis_nip ?? 'N/A' }}</div>
                                         </td>
                                         <td class="py-4 px-4">
                                             <div class="flex items-center">
@@ -164,10 +162,14 @@
                                             </div>
                                         </td>
                                         <td class="py-4 px-4">
-                                            <div class="text-sm text-gray-900">{{ \Carbon\Carbon::parse($internship->start_date)->format('d M Y') }}</div>
-                                            <div class="text-sm text-gray-500">s/d {{ \Carbon\Carbon::parse($internship->end_date)->format('d M Y') }}</div>
+                                            <div class="text-sm text-gray-900">{{ optional($internship->start_date)->format('d M Y') ?? '-' }}</div>
+                                            <div class="text-sm text-gray-500">s/d {{ optional($internship->end_date)->format('d M Y') ?? '-' }}</div>
                                             <div class="text-xs text-gray-400">
-                                                {{ \Carbon\Carbon::parse($internship->start_date)->diffInDays(\Carbon\Carbon::parse($internship->end_date)) }} hari
+                                                @if($internship->start_date && $internship->end_date)
+                                                    {{ $internship->start_date->diffInDays($internship->end_date) }} hari
+                                                @else
+                                                    -
+                                                @endif
                                             </div>
                                         </td>
                                         <td class="py-4 px-4">

--- a/simmas/resources/views/internships/index.blade.php
+++ b/simmas/resources/views/internships/index.blade.php
@@ -41,7 +41,7 @@
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                         </svg>
                     </div>
-                    <div class="text-3xl font-bold text-gray-900">{{ $internships->where('status', 'active')->count() }}</div>
+                    <div class="text-3xl font-bold text-gray-900">{{ $internships->where('status', 'Aktif')->count() }}</div>
                     <p class="text-xs text-gray-500 mt-1">Sedang magang</p>
                 </div>
 
@@ -53,7 +53,7 @@
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                         </svg>
                     </div>
-                    <div class="text-3xl font-bold text-gray-900">{{ $internships->where('status', 'completed')->count() }}</div>
+                    <div class="text-3xl font-bold text-gray-900">{{ $internships->where('status', 'Selesai')->count() }}</div>
                     <p class="text-xs text-gray-500 mt-1">Magang selesai</p>
                 </div>
 
@@ -65,7 +65,7 @@
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                         </svg>
                     </div>
-                    <div class="text-3xl font-bold text-gray-900">{{ $internships->where('status', 'pending')->count() }}</div>
+                    <div class="text-3xl font-bold text-gray-900">{{ $internships->where('status', 'Pending')->count() }}</div>
                     <p class="text-xs text-gray-500 mt-1">Menunggu penempatan</p>
                 </div>
             </div>
@@ -171,20 +171,20 @@
                                             </div>
                                         </td>
                                         <td class="py-4 px-4">
-                                            @if($internship->status == 'pending')
+                                            @if($internship->status == 'Pending')
                                                 <span class="px-3 py-1 inline-flex text-xs leading-5 font-semibold rounded-full bg-yellow-100 text-yellow-800">Pending</span>
-                                            @elseif($internship->status == 'active')
+                                            @elseif($internship->status == 'Aktif')
                                                 <span class="px-3 py-1 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">Aktif</span>
-                                            @elseif($internship->status == 'completed')
+                                            @elseif($internship->status == 'Selesai')
                                                 <span class="px-3 py-1 inline-flex text-xs leading-5 font-semibold rounded-full bg-blue-100 text-blue-800">Selesai</span>
-                                            @elseif($internship->status == 'cancelled')
+                                            @elseif($internship->status == 'Ditolak')
                                                 <span class="px-3 py-1 inline-flex text-xs leading-5 font-semibold rounded-full bg-red-100 text-red-800">Dibatalkan</span>
                                             @endif
                                         </td>
                                         <td class="py-4 px-4">
-                                            @if($internship->grade)
+                                            @if($internship->final_score)
                                                 <span class="inline-flex items-center justify-center w-10 h-10 rounded-full bg-lime-500 text-white font-bold">
-                                                    {{ $internship->grade }}
+                                                    {{ $internship->final_score }}
                                                 </span>
                                             @else
                                                 <span class="text-gray-400 text-sm">-</span>

--- a/simmas/resources/views/internships/show.blade.php
+++ b/simmas/resources/views/internships/show.blade.php
@@ -31,11 +31,11 @@
                         <div>
                             <div class="mb-4">
                                 <p class="text-sm font-medium text-gray-500">Tanggal Mulai</p>
-                                <p class="text-base">{{ \Carbon\Carbon::parse($internship->start_date)->format('d/m/Y') }}</p>
+                                <p class="text-base">{{ optional($internship->start_date)->format('d/m/Y') ?? '-' }}</p>
                             </div>
                             <div class="mb-4">
                                 <p class="text-sm font-medium text-gray-500">Tanggal Selesai</p>
-                                <p class="text-base">{{ \Carbon\Carbon::parse($internship->end_date)->format('d/m/Y') }}</p>
+                                <p class="text-base">{{ optional($internship->end_date)->format('d/m/Y') ?? '-' }}</p>
                             </div>
                             <div class="mb-4">
                                 <p class="text-sm font-medium text-gray-500">Status</p>
@@ -71,14 +71,14 @@
                                     @forelse ($internship->journals as $index => $journal)
                                         <tr class="odd:bg-white even:bg-gray-50">
                                             <td class="py-2.5 px-4 border-b border-gray-200">{{ $index + 1 }}</td>
-                                            <td class="py-2.5 px-4 border-b border-gray-200">{{ \Carbon\Carbon::parse($journal->date)->format('d/m/Y') }}</td>
-                                            <td class="py-2.5 px-4 border-b border-gray-200">{{ Str::limit($journal->activity, 100) }}</td>
+                                            <td class="py-2.5 px-4 border-b border-gray-200">{{ optional($journal->date)->format('d/m/Y') ?? '-' }}</td>
+                                            <td class="py-2.5 px-4 border-b border-gray-200">{{ \Illuminate\Support\Str::limit($journal->description, 100) }}</td>
                                             <td class="py-2.5 px-4 border-b border-gray-200">
-                                                @if($journal->status == 'pending')
+                                                @if($journal->status == 'Menunggu Verifikasi')
                                                     <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-yellow-100 text-yellow-800">Menunggu</span>
-                                                @elseif($journal->status == 'approved')
+                                                @elseif($journal->status == 'Disetujui')
                                                     <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">Disetujui</span>
-                                                @elseif($journal->status == 'rejected')
+                                                @elseif($journal->status == 'Ditolak')
                                                     <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-red-100 text-red-800">Ditolak</span>
                                                 @endif
                                             </td>

--- a/simmas/resources/views/internships/show.blade.php
+++ b/simmas/resources/views/internships/show.blade.php
@@ -40,13 +40,13 @@
                             <div class="mb-4">
                                 <p class="text-sm font-medium text-gray-500">Status</p>
                                 <div>
-                                    @if($internship->status == 'pending')
+                                    @if($internship->status == 'Pending')
                                         <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-yellow-100 text-yellow-800">Menunggu</span>
-                                    @elseif($internship->status == 'active')
+                                    @elseif($internship->status == 'Aktif')
                                         <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">Aktif</span>
-                                    @elseif($internship->status == 'completed')
+                                    @elseif($internship->status == 'Selesai')
                                         <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-blue-100 text-blue-800">Selesai</span>
-                                    @elseif($internship->status == 'cancelled')
+                                    @elseif($internship->status == 'Ditolak')
                                         <span class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-red-100 text-red-800">Dibatalkan</span>
                                     @endif
                                 </div>


### PR DESCRIPTION
Align internship status values in guru views with database values and update grade field to `final_score` to fix empty status display.

---
<a href="https://cursor.com/background-agent?bcId=bc-8d6b7111-2e0d-469b-8a40-57413a652e02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8d6b7111-2e0d-469b-8a40-57413a652e02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

