### PR TITLE
Fix sidebar logo not updating

### DIFF
--- a/simmas/app/Providers/AppServiceProvider.php
+++ b/simmas/app/Providers/AppServiceProvider.php
@@ -23,11 +23,7 @@ class AppServiceProvider extends ServiceProvider
     {
         // Share the school settings globally for layouts and components
         View::composer('*', function ($view) {
-            static $cachedSetting = null;
-            if ($cachedSetting === null) {
-                $cachedSetting = SchoolSetting::first();
-            }
-            $view->with('schoolSetting', $cachedSetting);
+            $view->with('schoolSetting', SchoolSetting::first());
         });
     }
 }

--- a/simmas/resources/views/layouts/app.blade.php
+++ b/simmas/resources/views/layouts/app.blade.php
@@ -25,7 +25,7 @@
                             <div class="flex items-center justify-between">
                                 <div class="flex items-center gap-3">
                                     @if(($schoolSetting->logo ?? null))
-                                        <img src="{{ Storage::disk('public')->url($schoolSetting->logo) . '?v=' . optional($schoolSetting->updated_at)->timestamp }}" alt="Logo" class="h-10 w-10 object-contain rounded-md border border-gray-200 p-1">
+                                        <img src="{{ asset('storage/' . $schoolSetting->logo) . '?v=' . optional($schoolSetting->updated_at)->timestamp }}" alt="Logo" class="h-10 w-10 object-contain rounded-md border border-gray-200 p-1">
                                     @endif
                                     <div>
                                         <h1 class="text-2xl font-bold text-gray-900">{{ $schoolSetting->name ?? 'Sekolah' }}</h1>

--- a/simmas/resources/views/layouts/app.blade.php
+++ b/simmas/resources/views/layouts/app.blade.php
@@ -25,7 +25,7 @@
                             <div class="flex items-center justify-between">
                                 <div class="flex items-center gap-3">
                                     @if(($schoolSetting->logo ?? null))
-                                        <img src="{{ Storage::disk('public')->url($schoolSetting->logo) }}" alt="Logo" class="h-10 w-10 object-contain rounded-md border border-gray-200 p-1">
+                                        <img src="{{ Storage::disk('public')->url($schoolSetting->logo) . '?v=' . optional($schoolSetting->updated_at)->timestamp }}" alt="Logo" class="h-10 w-10 object-contain rounded-md border border-gray-200 p-1">
                                     @endif
                                     <div>
                                         <h1 class="text-2xl font-bold text-gray-900">{{ $schoolSetting->name ?? 'Sekolah' }}</h1>

--- a/simmas/resources/views/layouts/sidebar.blade.php
+++ b/simmas/resources/views/layouts/sidebar.blade.php
@@ -13,7 +13,7 @@
     <div class="px-6 py-8 border-b border-gray-100">
         <div class="flex items-center gap-3">
             @if(($schoolSetting->logo ?? null))
-                <img src="{{ Storage::disk('public')->url($schoolSetting->logo) . '?v=' . optional($schoolSetting->updated_at)->timestamp }}" alt="Logo" class="w-10 h-10 rounded-lg border border-gray-200 p-1 object-contain">
+                <img src="{{ asset('storage/' . $schoolSetting->logo) . '?v=' . optional($schoolSetting->updated_at)->timestamp }}" alt="Logo" class="w-10 h-10 rounded-lg border border-gray-200 p-1 object-contain">
             @else
                 <div class="w-10 h-10 bg-blue-100 rounded-lg flex items-center justify-center">
                     <svg class="w-6 h-6 text-blue-600" fill="currentColor" viewBox="0 0 20 20">
@@ -190,7 +190,7 @@
         
         <div class="flex items-center gap-3">
             @if(($schoolSetting->logo ?? null))
-                <img src="{{ Storage::disk('public')->url($schoolSetting->logo) . '?v=' . optional($schoolSetting->updated_at)->timestamp }}" alt="Logo" class="w-8 h-8 rounded-lg border border-gray-200 p-1 object-contain">
+                <img src="{{ asset('storage/' . $schoolSetting->logo) . '?v=' . optional($schoolSetting->updated_at)->timestamp }}" alt="Logo" class="w-8 h-8 rounded-lg border border-gray-200 p-1 object-contain">
             @else
                 <div class="w-8 h-8 bg-blue-100 rounded-lg flex items-center justify-center">
                     <svg class="w-5 h-5 text-blue-600" fill="currentColor" viewBox="0 0 20 20">
@@ -219,7 +219,7 @@
             <div class="px-6 py-8">
                 <div class="flex items-center gap-3">
                     @if(($schoolSetting->logo ?? null))
-                        <img src="{{ Storage::disk('public')->url($schoolSetting->logo) . '?v=' . optional($schoolSetting->updated_at)->timestamp }}" alt="Logo" class="w-10 h-10 rounded-lg border border-gray-200 p-1 object-contain">
+                        <img src="{{ asset('storage/' . $schoolSetting->logo) . '?v=' . optional($schoolSetting->updated_at)->timestamp }}" alt="Logo" class="w-10 h-10 rounded-lg border border-gray-200 p-1 object-contain">
                     @else
                         <div class="w-10 h-10 bg-blue-100 rounded-lg flex items-center justify-center">
                             <svg class="w-6 h-6 text-blue-600" fill="currentColor" viewBox="0 0 20 20">

--- a/simmas/resources/views/layouts/sidebar.blade.php
+++ b/simmas/resources/views/layouts/sidebar.blade.php
@@ -13,7 +13,7 @@
     <div class="px-6 py-8 border-b border-gray-100">
         <div class="flex items-center gap-3">
             @if(($schoolSetting->logo ?? null))
-                <img src="{{ Storage::disk('public')->url($schoolSetting->logo) }}" alt="Logo" class="w-10 h-10 rounded-lg border border-gray-200 p-1 object-contain">
+                <img src="{{ Storage::disk('public')->url($schoolSetting->logo) . '?v=' . optional($schoolSetting->updated_at)->timestamp }}" alt="Logo" class="w-10 h-10 rounded-lg border border-gray-200 p-1 object-contain">
             @else
                 <div class="w-10 h-10 bg-blue-100 rounded-lg flex items-center justify-center">
                     <svg class="w-6 h-6 text-blue-600" fill="currentColor" viewBox="0 0 20 20">
@@ -190,7 +190,7 @@
         
         <div class="flex items-center gap-3">
             @if(($schoolSetting->logo ?? null))
-                <img src="{{ Storage::disk('public')->url($schoolSetting->logo) }}" alt="Logo" class="w-8 h-8 rounded-lg border border-gray-200 p-1 object-contain">
+                <img src="{{ Storage::disk('public')->url($schoolSetting->logo) . '?v=' . optional($schoolSetting->updated_at)->timestamp }}" alt="Logo" class="w-8 h-8 rounded-lg border border-gray-200 p-1 object-contain">
             @else
                 <div class="w-8 h-8 bg-blue-100 rounded-lg flex items-center justify-center">
                     <svg class="w-5 h-5 text-blue-600" fill="currentColor" viewBox="0 0 20 20">
@@ -218,13 +218,17 @@
         <aside class="relative z-50 w-64 bg-white h-full shadow-xl">
             <div class="px-6 py-8">
                 <div class="flex items-center gap-3">
-                    <div class="w-10 h-10 bg-blue-100 rounded-lg flex items-center justify-center">
-                        <svg class="w-6 h-6 text-blue-600" fill="currentColor" viewBox="0 0 20 20">
-                            <path d="M10.394 2.08a1 1 0 00-.788 0l-7 3a1 1 0 000 1.84L5.25 8.051a.999.999 0 01.356-.257l4-1.714a1 1 0 11.788 1.838L7.667 9.088l1.94.831a1 1 0 00.787 0l7-3a1 1 0 000-1.838l-7-3zM3.31 9.397L5 10.12v4.102a8.969 8.969 0 00-1.05-.174 1 1 0 01-.89-.89 11.115 11.115 0 01.25-3.762zM9.3 16.573A9.026 9.026 0 007 14.935v-3.957l1.818.78a3 3 0 002.364 0l5.508-2.361a11.026 11.026 0 01.25 3.762 1 1 0 01-.89.89 8.968 8.968 0 00-5.35 2.524 1 1 0 01-1.4 0zM6 18a1 1 0 001-1v-2.065a8.935 8.935 0 00-2-.712V17a1 1 0 001 1z"/>
-                        </svg>
-                    </div>
+                    @if(($schoolSetting->logo ?? null))
+                        <img src="{{ Storage::disk('public')->url($schoolSetting->logo) . '?v=' . optional($schoolSetting->updated_at)->timestamp }}" alt="Logo" class="w-10 h-10 rounded-lg border border-gray-200 p-1 object-contain">
+                    @else
+                        <div class="w-10 h-10 bg-blue-100 rounded-lg flex items-center justify-center">
+                            <svg class="w-6 h-6 text-blue-600" fill="currentColor" viewBox="0 0 20 20">
+                                <path d="M10.394 2.08a1 1 0 00-.788 0l-7 3a1 1 0 000 1.84L5.25 8.051a.999.999 0 01.356-.257l4-1.714a1 1 0 11.788 1.838L7.667 9.088l1.94.831a1 1 0 00.787 0l7-3a1 1 0 000-1.838l-7-3zM3.31 9.397L5 10.12v4.102a8.969 8.969 0 00-1.05-.174 1 1 0 01-.89-.89 11.115 11.115 0 01.25-3.762zM9.3 16.573A9.026 9.026 0 007 14.935v-3.957l1.818.78a3 3 0 002.364 0l5.508-2.361a11.026 11.026 0 01.25 3.762 1 1 0 01-.89.89 8.968 8.968 0 00-5.35 2.524 1 1 0 01-1.4 0zM6 18a1 1 0 001-1v-2.065a8.935 8.935 0 00-2-.712V17a1 1 0 001 1z"/>
+                            </svg>
+                        </div>
+                    @endif
                     <div>
-                        <h1 class="text-xl font-bold text-gray-900">SIMMAS</h1>
+                        <h1 class="text-xl font-bold text-gray-900">{{ $schoolSetting->name ?? 'SIMMAS' }}</h1>
                         <p class="text-sm text-gray-600">{{ $panelLabel }}</p>
                     </div>
                 </div>

--- a/simmas/resources/views/school-settings/edit.blade.php
+++ b/simmas/resources/views/school-settings/edit.blade.php
@@ -51,7 +51,7 @@
                                     </label>
                                     @if($setting->logo)
                                         <div class="mb-3">
-                                            <img src="{{ Storage::disk('public')->url($setting->logo) }}" alt="Logo" class="h-20 w-20 object-contain border border-gray-200 rounded-lg p-2">
+                                            <img src="{{ Storage::disk('public')->url($setting->logo) . '?v=' . optional($setting->updated_at)->timestamp }}" alt="Logo" class="h-20 w-20 object-contain border border-gray-200 rounded-lg p-2">
                                         </div>
                                     @endif
                                     <input 
@@ -240,7 +240,7 @@
                         <p class="text-xs font-medium text-gray-500 mb-3">Dashboard Header</p>
                         <div class="bg-gray-50 rounded-lg p-4 flex items-center gap-4">
                             @if($setting->logo)
-                                <img src="{{ Storage::disk('public')->url($setting->logo) }}" alt="Logo" class="h-12 w-12 object-contain">
+                                <img src="{{ Storage::disk('public')->url($setting->logo) . '?v=' . optional($setting->updated_at)->timestamp }}" alt="Logo" class="h-12 w-12 object-contain">
                             @else
                                 <div class="h-12 w-12 bg-gray-200 rounded-lg flex items-center justify-center">
                                     <svg class="w-6 h-6 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -261,7 +261,7 @@
                         <div class="bg-white border-2 border-gray-300 rounded-lg p-6">
                             <div class="flex items-start gap-4">
                                 @if($setting->logo)
-                                    <img src="{{ Storage::disk('public')->url($setting->logo) }}" alt="Logo" class="h-16 w-16 object-contain flex-shrink-0">
+                                    <img src="{{ Storage::disk('public')->url($setting->logo) . '?v=' . optional($setting->updated_at)->timestamp }}" alt="Logo" class="h-16 w-16 object-contain flex-shrink-0">
                                 @else
                                     <div class="h-16 w-16 bg-gray-100 rounded flex items-center justify-center flex-shrink-0">
                                         <svg class="w-8 h-8 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -293,7 +293,7 @@
                         <div class="bg-white border border-gray-300 rounded-lg p-4">
                             <div class="flex items-center gap-3 mb-3 pb-3 border-b border-gray-200">
                                 @if($setting->logo)
-                                    <img src="{{ Storage::disk('public')->url($setting->logo) }}" alt="Logo" class="h-12 w-12 object-contain">
+                                    <img src="{{ Storage::disk('public')->url($setting->logo) . '?v=' . optional($setting->updated_at)->timestamp }}" alt="Logo" class="h-12 w-12 object-contain">
                                 @else
                                     <div class="h-12 w-12 bg-gray-100 rounded flex items-center justify-center">
                                         <svg class="w-6 h-6 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/simmas/resources/views/school-settings/edit.blade.php
+++ b/simmas/resources/views/school-settings/edit.blade.php
@@ -51,7 +51,7 @@
                                     </label>
                                     @if($setting->logo)
                                         <div class="mb-3">
-                                            <img src="{{ Storage::disk('public')->url($setting->logo) . '?v=' . optional($setting->updated_at)->timestamp }}" alt="Logo" class="h-20 w-20 object-contain border border-gray-200 rounded-lg p-2">
+                                            <img src="{{ asset('storage/' . $setting->logo) . '?v=' . optional($setting->updated_at)->timestamp }}" alt="Logo" class="h-20 w-20 object-contain border border-gray-200 rounded-lg p-2">
                                         </div>
                                     @endif
                                     <input 
@@ -240,7 +240,7 @@
                         <p class="text-xs font-medium text-gray-500 mb-3">Dashboard Header</p>
                         <div class="bg-gray-50 rounded-lg p-4 flex items-center gap-4">
                             @if($setting->logo)
-                                <img src="{{ Storage::disk('public')->url($setting->logo) . '?v=' . optional($setting->updated_at)->timestamp }}" alt="Logo" class="h-12 w-12 object-contain">
+                                <img src="{{ asset('storage/' . $setting->logo) . '?v=' . optional($setting->updated_at)->timestamp }}" alt="Logo" class="h-12 w-12 object-contain">
                             @else
                                 <div class="h-12 w-12 bg-gray-200 rounded-lg flex items-center justify-center">
                                     <svg class="w-6 h-6 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -261,7 +261,7 @@
                         <div class="bg-white border-2 border-gray-300 rounded-lg p-6">
                             <div class="flex items-start gap-4">
                                 @if($setting->logo)
-                                    <img src="{{ Storage::disk('public')->url($setting->logo) . '?v=' . optional($setting->updated_at)->timestamp }}" alt="Logo" class="h-16 w-16 object-contain flex-shrink-0">
+                                    <img src="{{ asset('storage/' . $setting->logo) . '?v=' . optional($setting->updated_at)->timestamp }}" alt="Logo" class="h-16 w-16 object-contain flex-shrink-0">
                                 @else
                                     <div class="h-16 w-16 bg-gray-100 rounded flex items-center justify-center flex-shrink-0">
                                         <svg class="w-8 h-8 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -293,7 +293,7 @@
                         <div class="bg-white border border-gray-300 rounded-lg p-4">
                             <div class="flex items-center gap-3 mb-3 pb-3 border-b border-gray-200">
                                 @if($setting->logo)
-                                    <img src="{{ Storage::disk('public')->url($setting->logo) . '?v=' . optional($setting->updated_at)->timestamp }}" alt="Logo" class="h-12 w-12 object-contain">
+                                    <img src="{{ asset('storage/' . $setting->logo) . '?v=' . optional($setting->updated_at)->timestamp }}" alt="Logo" class="h-12 w-12 object-contain">
                                 @else
                                     <div class="h-12 w-12 bg-gray-100 rounded flex items-center justify-center">
                                         <svg class="w-6 h-6 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">


### PR DESCRIPTION
Remove static cache for school settings and add cache-busting to logo URLs to ensure logo updates are immediately reflected across the application.

The `schoolSetting` was statically cached in `AppServiceProvider`, preventing updates (like logo changes) from being reloaded. This PR removes the static cache and adds a timestamp-based query parameter to logo URLs to bypass browser/CDN caching, ensuring new logos appear instantly. The mobile drawer header was also updated to consistently display the school's logo and name.

---
<a href="https://cursor.com/background-agent?bcId=bc-58b80a70-77ff-4530-acd9-5bcebca6d160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-58b80a70-77ff-4530-acd9-5bcebca6d160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

